### PR TITLE
Add Vitest setup and sample test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "type": "module",
     "scripts": {
         "build": "vite build",
-        "dev": "vite"
+        "dev": "vite",
+        "test": "vitest"
     },
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.2",
@@ -16,6 +17,8 @@
         "laravel-vite-plugin": "^1.2.0",
         "postcss": "^8.4.31",
         "tailwindcss": "^3.1.0",
-        "vite": "^6.2.4"
+        "vite": "^6.2.4",
+        "vitest": "^1.0.0",
+        "jsdom": "^22.0.0"
     }
 }

--- a/resources/js/__tests__/alpine.test.js
+++ b/resources/js/__tests__/alpine.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest'
+
+const startMock = vi.fn()
+vi.mock('alpinejs', () => ({ default: { start: startMock } }))
+
+import '../app.js'
+
+describe('Alpine initialization', () => {
+  it('adds Alpine to window and calls start', () => {
+    expect(window.Alpine).toBeDefined()
+    expect(startMock).toHaveBeenCalled()
+  })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+})


### PR DESCRIPTION
## Summary
- add `vitest` test script and dev dependencies
- configure Vitest with jsdom environment
- provide a basic Alpine test

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f17fa8f188324bf2d1c5701aa8042