### PR TITLE
Add Cypress setup

### DIFF
--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -1,0 +1,6 @@
+describe('Login page', () => {
+  it('shows Login heading', () => {
+    cy.visit('/login');
+    cy.contains('h1', 'Login').should('exist');
+  });
+});

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,0 +1,6 @@
+// Import commands.js using ES2015 syntax:
+// import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "type": "module",
     "scripts": {
         "build": "vite build",
-        "dev": "vite"
+        "dev": "vite",
+        "cy:open": "cypress open",
+        "cy:run": "cypress run"
     },
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.2",
@@ -16,6 +18,7 @@
         "laravel-vite-plugin": "^1.2.0",
         "postcss": "^8.4.31",
         "tailwindcss": "^3.1.0",
-        "vite": "^6.2.4"
+        "vite": "^6.2.4",
+        "cypress": "^13.7.0"
     }
 }


### PR DESCRIPTION
## Summary
- install Cypress dev dependency and add cypress scripts
- configure basic Cypress folder
- add a login spec that checks the Login heading

## Testing
- `npm run cy:run` *(fails: cypress: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f17ff561483249460a4d7681654d4