### PR TITLE
Update CSRF exclusion for Midtrans callbacks

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -42,7 +42,7 @@ class VerifyCsrfToken
      * @var array<int, string>
      */
     protected $except = [
-        'midtrans/callback',
+        'midtrans/*',
     ];
 
     /**


### PR DESCRIPTION
## Summary
- broaden CSRF exemption to all Midtrans routes

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f27b1f9108324b3bcd95b8ac5cbc2