### PR TITLE
Fix route syntax in sidebar

### DIFF
--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -68,7 +68,7 @@
         <div id="collapseTwo" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
             <div class="bg-white py-2 collapse-inner rounded">
                 <h6 class="collapse-header">Manajemen Kelas</h6>
-                <a class="collapse-item" href="{{ route(name: 'tahun-ajaran.index') }}">Tahun Ajaran</a>
+                <a class="collapse-item" href="{{ route('tahun-ajaran.index') }}">Tahun Ajaran</a>
                 <a class="collapse-item" href="{{ route('kelas.index') }}">Kelas</a>
             </div>
         </div>
@@ -85,7 +85,7 @@
             data-parent="#accordionSidebar">
             <div class="bg-white py-2 collapse-inner rounded">
                 <h6 class="collapse-header">Data Siswa</h6>
-                <a class="collapse-item" href="{{ route(name: 'siswa.index') }}">Biodata Siswa</a>
+                <a class="collapse-item" href="{{ route('siswa.index') }}">Biodata Siswa</a>
             </div>
         </div>
     </li>
@@ -100,14 +100,14 @@
         <div id="collapseUtilities" class="collapse" aria-labelledby="headingUtilities" data-parent="#accordionSidebar">
             <div class="bg-white py-2 collapse-inner rounded">
                 <h6 class="collapse-header">Data Siswa</h6>
-                <a class="collapse-item" href="{{ route(name: 'jenis.index') }}">Jenis Iuran</a>
-                <a class="collapse-item" href="{{ route(name: 'iuran.index') }}">Iuran</a>
-                <a class="collapse-item" href="{{ route(name: 'keuangan.index') }}">Keuangan</a>
-                <a class="collapse-item" href="{{ route(name: 'riwayat.index') }}">Riwayat Pembayaran</a>
-                <a class="collapse-item" href="{{ route(name: 'cek-pembayaran.index') }}">Cek Pembayaran</a>
-                <a class="collapse-item" href="{{ route(name: 'jurnal-umum.index') }}">Jurnal Umum</a>
-                <a class="collapse-item" href="{{ route(name: 'users.index') }}">User Management</a>
-                <a class="collapse-item" href="{{ route(name: 'settings.index') }}">Application Settings</a>
+                <a class="collapse-item" href="{{ route('jenis.index') }}">Jenis Iuran</a>
+                <a class="collapse-item" href="{{ route('iuran.index') }}">Iuran</a>
+                <a class="collapse-item" href="{{ route('keuangan.index') }}">Keuangan</a>
+                <a class="collapse-item" href="{{ route('riwayat.index') }}">Riwayat Pembayaran</a>
+                <a class="collapse-item" href="{{ route('cek-pembayaran.index') }}">Cek Pembayaran</a>
+                <a class="collapse-item" href="{{ route('jurnal-umum.index') }}">Jurnal Umum</a>
+                <a class="collapse-item" href="{{ route('users.index') }}">User Management</a>
+                <a class="collapse-item" href="{{ route('settings.index') }}">Application Settings</a>
 
 
             </div>
@@ -132,8 +132,8 @@
                 data-parent="#accordionSidebar">
                 <div class="bg-white py-2 collapse-inner rounded">
                     <h6 class="collapse-header">Settings</h6>
-                    <a class="collapse-item" href="{{ route(name: 'users.index') }}">User Management</a>
-                    <a class="collapse-item" href="{{ route(name: 'settings.index') }}">Application Settings</a>
+                    <a class="collapse-item" href="{{ route('users.index') }}">User Management</a>
+                    <a class="collapse-item" href="{{ route('settings.index') }}">Application Settings</a>
 
 
 


### PR DESCRIPTION
## Summary
- replace deprecated `route(name:...)` calls with `route(...)`
- add newline at EOF

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f28809db08324a371b42e5caa1a55