### PR TITLE
Add payment status table on dashboard

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -34,10 +34,32 @@ class DashboardController extends Controller
             ->distinct('siswa_id')
             ->count();
 
+        // Total nominal pembayaran yang sudah diterima
+        $totalReceived = Pembayaran::where('status', 'settlement')->sum('jumlah');
+
+        // Total nominal pembayaran yang masih pending
+        $totalPending = Pembayaran::where('status', 'pending')->sum('jumlah');
+
+        // Status pembayaran per siswa
+        $studentStatuses = Siswa::with('kelas')->get()->map(function ($s) {
+            $hasPending = Iuran::where('siswa_id', $s->id)
+                ->where('status', 'pending')
+                ->exists();
+
+            return [
+                'nama' => $s->nama_depan . ' ' . $s->nama_belakang,
+                'kelas' => optional($s->kelas)->nama,
+                'status' => $hasPending ? 'Belum Lunas' : 'Lunas',
+            ];
+        });
+
         return view('dashboard.admin', compact(
             'activeStudents',
             'paymentsThisMonth',
-            'pendingStudents'
+            'pendingStudents',
+            'totalReceived',
+            'totalPending',
+            'studentStatuses'
         ));
     }
 

--- a/app/Models/Siswa.php
+++ b/app/Models/Siswa.php
@@ -5,6 +5,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Kelas;
+use App\Models\Iuran;
 
 class Siswa extends Model
 {
@@ -36,5 +37,13 @@ class Siswa extends Model
     public function kelas()
     {
         return $this->belongsTo(Kelas::class, 'kelas_id');
+    }
+
+    /**
+     * Relasi ke Iuran (hasMany)
+     */
+    public function iuran()
+    {
+        return $this->hasMany(Iuran::class, 'siswa_id');
     }
 }

--- a/resources/views/dashboard/admin.blade.php
+++ b/resources/views/dashboard/admin.blade.php
@@ -30,5 +30,51 @@
       </div>
     </div>
   </div>
+
+  <script src="{{ asset('vendor/sb-admin-2/vendor/chart.js/Chart.min.js') }}"></script>
+
+  <canvas id="paymentChart"></canvas>
+
+  <h5 class="mt-4">Status Pembayaran Siswa</h5>
+  <table class="table table-striped" id="studentStatusTable">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Nama</th>
+        <th>Kelas</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      @foreach($studentStatuses as $idx => $s)
+      <tr>
+        <td>{{ $idx + 1 }}</td>
+        <td>{{ $s['nama'] }}</td>
+        <td>{{ $s['kelas'] }}</td>
+        <td>
+          <span class="badge badge-{{ $s['status'] == 'Lunas' ? 'success' : 'warning' }}">
+            {{ $s['status'] }}
+          </span>
+        </td>
+      </tr>
+      @endforeach
+    </tbody>
+  </table>
 </div>
+@push('scripts')
+<script>
+    const ctx = document.getElementById('paymentChart').getContext('2d');
+    new Chart(ctx, {
+        type: 'doughnut',
+        data: {
+            labels: ['Diterima', 'Pending'],
+            datasets: [{
+                data: [{{ $totalReceived }}, {{ $totalPending }}],
+                backgroundColor: ['#1cc88a', '#f6c23e'],
+            }]
+        }
+    });
+</script>
+@endpush
+
 @endsection

--- a/tests/Feature/AdminDashboardTest.php
+++ b/tests/Feature/AdminDashboardTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Middleware\RoleMiddleware;
+
+class AdminDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::create(['name' => 'admin']);
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('admin');
+
+        $this->withoutMiddleware([
+            RoleMiddleware::class,
+        ]);
+    }
+
+    public function test_dashboard_displays_chart_and_status_table(): void
+    {
+        $response = $this->actingAs($this->admin)->get('/dashboard');
+
+        $response->assertStatus(200)
+                 ->assertSee('id="paymentChart"', false)
+                 ->assertSee('id="studentStatusTable"', false);
+    }
+}


### PR DESCRIPTION
## Summary
- compute per-student payment status in DashboardController
- show status table on admin dashboard
- expose iuran relation on Siswa model
- update feature test for chart and status table

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f287f06b0832480f6d79abf62b2c9