### PR TITLE
Add payment status table to admin dashboard

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -37,12 +37,19 @@ class DashboardController extends Controller
         $totalReceived = Pembayaran::where('status', 'settlement')->sum('jumlah');
         $totalPending  = Pembayaran::where('status', 'pending')->sum('jumlah');
 
+        $studentPayments = Siswa::with('kelas')
+            ->withCount([
+                'iuran as pending_iuran_count' => fn($q) => $q->where('status', 'pending')
+            ])
+            ->get();
+
         return view('dashboard.admin', compact(
             'activeStudents',
             'paymentsThisMonth',
             'pendingStudents',
             'totalReceived',
-            'totalPending'
+            'totalPending',
+            'studentPayments'
         ));
     }
 

--- a/app/Models/Siswa.php
+++ b/app/Models/Siswa.php
@@ -5,6 +5,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Kelas;
+use App\Models\Iuran;
 
 class Siswa extends Model
 {
@@ -36,5 +37,13 @@ class Siswa extends Model
     public function kelas()
     {
         return $this->belongsTo(Kelas::class, 'kelas_id');
+    }
+
+    /**
+     * Relasi ke Iuran (hasMany)
+     */
+    public function iuran()
+    {
+        return $this->hasMany(Iuran::class, 'siswa_id');
     }
 }

--- a/resources/views/dashboard/admin.blade.php
+++ b/resources/views/dashboard/admin.blade.php
@@ -32,8 +32,36 @@
   </div>
   <div class="card mt-4">
     <div class="card-body">
-      <canvas id="paymentStatusChart"></canvas>
+      <canvas id="paymentChart"></canvas>
     </div>
+  </div>
+
+  <div class="card shadow-sm mt-4">
+      <div class="card-body">
+          <h5 class="card-title">Status Pembayaran Siswa</h5>
+          <table class="table table-bordered">
+              <thead>
+                  <tr>
+                      <th>NIS</th>
+                      <th>Nama</th>
+                      <th>Status</th>
+                  </tr>
+              </thead>
+              <tbody>
+                  @foreach($studentPayments as $s)
+                  <tr>
+                      <td>{{ $s->nis }}</td>
+                      <td>{{ $s->nama_depan }} {{ $s->nama_belakang }}</td>
+                      <td>
+                          <span class="badge badge-{{ $s->pending_iuran_count ? 'warning' : 'success' }}">
+                              {{ $s->pending_iuran_count ? 'Belum Lunas' : 'Lunas' }}
+                          </span>
+                      </td>
+                  </tr>
+                  @endforeach
+              </tbody>
+          </table>
+      </div>
   </div>
 </div>
 @endsection
@@ -42,7 +70,7 @@
 <script src="{{ asset('vendor/sb-admin-2/vendor/chart.js/Chart.min.js') }}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-    new Chart(document.getElementById('paymentStatusChart'), {
+    new Chart(document.getElementById('paymentChart'), {
         type: 'doughnut',
         data: {
             labels: ['Diterima', 'Pending'],

--- a/tests/Feature/AdminDashboardTest.php
+++ b/tests/Feature/AdminDashboardTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use App\Models\TahunAjaran;
+use App\Models\Kelas;
+use App\Models\Siswa;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Middleware\RoleMiddleware;
+use Spatie\Permission\Middleware\PermissionMiddleware;
+
+class AdminDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware([
+            RoleMiddleware::class,
+            PermissionMiddleware::class,
+        ]);
+
+        Role::create(['name' => 'admin']);
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('admin');
+    }
+
+    public function test_dashboard_displays_payment_table(): void
+    {
+        $ta = TahunAjaran::create([
+            'nama' => '2025/2026',
+            'semester' => 'Ganjil',
+            'aktif' => true,
+        ]);
+
+        $kelas = Kelas::create([
+            'nama' => 'X IPA',
+            'kapasitas' => 30,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+
+        Siswa::create([
+            'nis' => '001',
+            'nisn' => null,
+            'nama_depan' => 'Test',
+            'nama_belakang' => 'User',
+            'email' => 'test@example.com',
+            'kelas_id' => $kelas->id,
+        ]);
+
+        $response = $this->actingAs($this->admin)->get('/dashboard');
+
+        $response->assertStatus(200)
+                 ->assertSee('id="paymentChart"', false)
+                 ->assertSee('Status Pembayaran Siswa');
+    }
+}
+


### PR DESCRIPTION
## Summary
- define iuran relation on `Siswa`
- show pending payment status counts in admin dashboard
- render a payment status table in admin dashboard view
- cover admin dashboard table in feature test

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f30718e888324a53d7387592537ab