### PR TITLE
Auto create user on Siswa creation

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -22,6 +22,13 @@ class AuthenticatedSessionController extends Controller
         $request->authenticate();
         $request->session()->regenerate();
 
+        $user = Auth::user();
+        if ($user->must_change_password) {
+            return redirect()
+                ->route('profile.edit')
+                ->with('status', 'must-change-password');
+        }
+
         // Redirect sesuai role via RouteServiceProvider::home()
         return redirect()->intended(RouteServiceProvider::home());
     }

--- a/app/Http/Controllers/Auth/PasswordController.php
+++ b/app/Http/Controllers/Auth/PasswordController.php
@@ -22,6 +22,7 @@ class PasswordController extends Controller
 
         $request->user()->update([
             'password' => Hash::make($validated['password']),
+            'must_change_password' => false,
         ]);
 
         return back()->with('status', 'password-updated');

--- a/app/Http/Controllers/SiswaController.php
+++ b/app/Http/Controllers/SiswaController.php
@@ -9,6 +9,7 @@ use App\Imports\SiswaImport;
 use Maatwebsite\Excel\Facades\Excel;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rule;
 
 class SiswaController extends Controller
 {
@@ -46,7 +47,7 @@ class SiswaController extends Controller
             'nama_depan'         => 'required|string|max:50',
             'nama_belakang'      => 'required|string|max:50',
             'foto'               => 'nullable|image|max:2048',
-            'email'              => 'required|email|unique:siswa,email',
+            'email'              => 'required|email|unique:siswa,email|unique:users,email',
             'tanggal_lahir'      => 'nullable|date',
             'jenis_kelamin'      => 'nullable|in:Laki-laki,Perempuan',
             'alamat'             => 'nullable|string',
@@ -89,7 +90,12 @@ class SiswaController extends Controller
             'nama_depan'         => 'required|string|max:50',
             'nama_belakang'      => 'required|string|max:50',
             'foto'               => 'nullable|image|max:2048',
-            'email'              => "required|email|unique:siswa,email,{$siswa->id}",
+            'email'              => [
+                'required',
+                'email',
+                "unique:siswa,email,{$siswa->id}",
+                Rule::unique('users', 'email')->ignore($siswa->email, 'email'),
+            ],
             'tanggal_lahir'      => 'nullable|date',
             'jenis_kelamin'      => 'nullable|in:Laki-laki,Perempuan',
             'alamat'             => 'nullable|string',

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -54,5 +54,6 @@ class Kernel extends HttpKernel
         // Spatie Permission
         'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
         'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
+        'mustchange' => \App\Http\Middleware\EnsurePasswordChanged::class,
     ];
 }

--- a/app/Http/Middleware/EnsurePasswordChanged.php
+++ b/app/Http/Middleware/EnsurePasswordChanged.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsurePasswordChanged
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (Auth::check() && Auth::user()->must_change_password) {
+            if (! $request->routeIs('profile.edit') &&
+                ! $request->routeIs('password.update') &&
+                ! $request->routeIs('logout')) {
+                return redirect()->route('profile.edit')
+                    ->with('status', 'must-change-password');
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Siswa.php
+++ b/app/Models/Siswa.php
@@ -6,6 +6,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Kelas;
 use App\Models\Iuran;
+use App\Models\User;
+use Illuminate\Support\Carbon;
 
 class Siswa extends Model
 {
@@ -45,5 +47,23 @@ class Siswa extends Model
     public function iuran()
     {
         return $this->hasMany(Iuran::class, 'siswa_id');
+    }
+
+    protected static function booted()
+    {
+        static::created(function (Siswa $siswa) {
+            $birth = $siswa->tanggal_lahir
+                ? Carbon::parse($siswa->tanggal_lahir)->format('dmy')
+                : '';
+            $password = $siswa->nama_depan . $birth;
+
+            $user = User::create([
+                'name' => $siswa->nama_depan . ' ' . $siswa->nama_belakang,
+                'email' => $siswa->email,
+                'password' => $password,
+            ]);
+
+            $user->assignRole('siswa');
+        });
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -27,6 +27,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'must_change_password',
     ];
 
     /**
@@ -49,6 +50,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'must_change_password' => 'boolean',
         ];
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'must_change_password' => false,
         ];
     }
 

--- a/database/migrations/2025_06_14_000001_add_must_change_password_to_users_table.php
+++ b/database/migrations/2025_06_14_000001_add_must_change_password_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('must_change_password')->default(true);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('must_change_password');
+        });
+    }
+};

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -21,6 +21,7 @@ class UserSeeder extends Seeder
             'name' => 'Admin Sekolah',
             'email' => 'admin@example.com',
             'password' => Hash::make('admin123'),
+            'must_change_password' => false,
         ]);
         $admin->assignRole($adminRole);
 
@@ -29,15 +30,8 @@ class UserSeeder extends Seeder
             'name' => 'Operator Sekolah',
             'email' => 'operator@example.com',
             'password' => Hash::make('admin123'),
+            'must_change_password' => false,
         ]);
         $operator->assignRole($operatorRole);
-
-        // Siswa
-        $siswa = User::create([
-            'name' => 'Siswa Aktif',
-            'email' => 'siswa1@example.com',
-            'password' => Hash::make('admin123'),
-        ]);
-        $siswa->assignRole($siswaRole);
     }
 }

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -6,6 +6,11 @@
     </x-slot>
 
     <div class="py-12">
+        @if (session('status') === 'must-change-password')
+            <div class="mb-4 p-4 bg-red-100 text-red-800 rounded">
+                {{ __('Please change your password before continuing.') }}
+            </div>
+        @endif
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
             <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
                 <div class="max-w-xl">

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,28 +29,28 @@ Route::post('midtrans/callback', [PembayaranController::class, 'callback'])
     ->name('midtrans.callback');
 
 
-Route::middleware('auth')->group(function () {
+Route::middleware(['auth', 'mustchange'])->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
-Route::group(['middleware' => ['auth', 'role:admin']], function () {
+Route::group(['middleware' => ['auth', 'mustchange', 'role:admin']], function () {
     Route::resource('tahun-ajaran', TahunAjaranController::class);
 });
 
-Route::group(['middleware' => ['auth', 'role:admin']], function () {
+Route::group(['middleware' => ['auth', 'mustchange', 'role:admin']], function () {
     Route::resource('kelas', KelasController::class);
 });
 
-Route::group(['middleware' => ['auth', 'role:admin']], function () {
+Route::group(['middleware' => ['auth', 'mustchange', 'role:admin']], function () {
     Route::resource('siswa', SiswaController::class);
     Route::post('siswa/import', [SiswaController::class, 'import'])
         ->name('siswa.import');
 });
 
 
-Route::group(['middleware' => ['auth', 'role:admin']], function () {
+Route::group(['middleware' => ['auth', 'mustchange', 'role:admin']], function () {
     // Jenis Pembayaran
     Route::get('jenis-pembayaran', [Modul6Controller::class, 'indexJenis'])->name('jenis.index');
     Route::get('jenis-pembayaran/create', [Modul6Controller::class, 'createJenis'])->name('jenis.create');
@@ -69,7 +69,7 @@ Route::group(['middleware' => ['auth', 'role:admin']], function () {
 });
 
 
-Route::middleware(['auth', 'role:admin|operator'])->group(function () {
+Route::middleware(['auth', 'mustchange', 'role:admin|operator'])->group(function () {
     Route::get('jurnal-umum', [JurnalUmumController::class, 'index'])
         ->name('jurnal-umum.index');
     Route::get('jurnal-umum/create', [JurnalUmumController::class, 'create'])
@@ -85,7 +85,7 @@ Route::middleware(['auth', 'role:admin|operator'])->group(function () {
 
 
 
-Route::middleware(['auth', 'role:admin|operator'])->group(function () {
+Route::middleware(['auth', 'mustchange', 'role:admin|operator'])->group(function () {
     // 1) Tampilkan daftar iuran pending
     Route::get('/pembayaran', [PembayaranController::class, 'form'])->name('pembayaran.index');
 
@@ -96,13 +96,13 @@ Route::middleware(['auth', 'role:admin|operator'])->group(function () {
 
 
 // Admin-only dashboard
-Route::middleware(['auth', 'role:admin'])->group(function () {
+Route::middleware(['auth', 'mustchange', 'role:admin'])->group(function () {
     Route::get('/dashboard', [DashboardController::class, 'admin'])
         ->name('dashboard.admin');
 });
 
 // Siswa-only dashboard
-Route::middleware(['auth', 'role:siswa'])->group(function () {
+Route::middleware(['auth', 'mustchange', 'role:siswa'])->group(function () {
     Route::get('/dashboard-siswa', [DashboardController::class, 'student'])
         ->name('dashboard.student');
 });
@@ -112,13 +112,13 @@ Route::get('/cek-pembayaran', [CekPembayaranController::class, 'index'])->name('
 Route::post('/cek-pembayaran', [CekPembayaranController::class, 'show'])->name('cek-pembayaran.show');
 
 
-Route::middleware(['auth'])->group(function () {
+Route::middleware(['auth', 'mustchange'])->group(function () {
     Route::get('/riwayat-transaksi', [RiwayatTransaksiController::class, 'index'])->name('riwayat.index');
     Route::get('/riwayat-transaksi/{id}', [RiwayatTransaksiController::class, 'show'])->name('riwayat.show');
 });
 
 
-Route::middleware(['auth', 'role:admin|operator'])->group(function () {
+Route::middleware(['auth', 'mustchange', 'role:admin|operator'])->group(function () {
     Route::get('/keuangan', [KeuanganController::class, 'index'])->name('keuangan.index');
     Route::get('/keuangan/tambah', [KeuanganController::class, 'create'])->name('keuangan.create');
     Route::post('/keuangan', [KeuanganController::class, 'store'])->name('keuangan.store');
@@ -128,7 +128,7 @@ Route::get('/keuangan/export-excel', [KeuanganController::class, 'exportExcel'])
 Route::get('/keuangan/cetak-pdf', [KeuanganController::class, 'exportPdf'])->name('keuangan.export-pdf');
 
 
-Route::middleware(['auth', 'role:admin|operator'])->group(function () {
+Route::middleware(['auth', 'mustchange', 'role:admin|operator'])->group(function () {
     Route::get('/laporan', [LaporanController::class, 'index'])
         ->name('laporan.index');
     Route::post('/laporan', [LaporanController::class, 'generate'])
@@ -140,7 +140,7 @@ Route::middleware(['auth', 'role:admin|operator'])->group(function () {
 });
 
 
-Route::middleware(['auth', 'role:admin'])->group(function () {
+Route::middleware(['auth', 'mustchange', 'role:admin'])->group(function () {
     // Tampilkan halaman settings
     Route::get('settings', [SettingsController::class, 'index'])->name('settings.index');
 
@@ -160,7 +160,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::post('settings/restore-upload', [SettingsController::class, 'restoreUpload'])->name('settings.restore.upload');
 });
 
-Route::middleware(['auth', 'role:admin'])->group(function () {
+Route::middleware(['auth', 'mustchange', 'role:admin'])->group(function () {
     Route::resource('users', UserController::class);
 });
 


### PR DESCRIPTION
## Summary
- create migration to track if a user must change password
- generate user account automatically when a new Siswa is created
- force password change on first login
- update seeders, factories and middleware
- enforce email uniqueness across users

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f393b9f4c83249c2e3cbba4cb2a0f