### PR TITLE
Add test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-8.2-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-8.2-
+
+      - run: composer install --no-progress --prefer-dist
+
+      - run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+
+      - run: php artisan key:generate
+
+      - run: composer test


### PR DESCRIPTION
## Summary
- add CI workflow for running PHP tests

## Testing
- `composer test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_684f470b23a883249eecde970da05744