### PR TITLE
Add DataTables support

### DIFF
--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -12,5 +12,7 @@
 <link href="{{ asset('vendor/sb-admin-2/vendor/fontawesome-free/css/all.min.css') }}" rel="stylesheet" type="text/css">
 <link href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i" rel="stylesheet">
 
-<!-- Custom styles for this template-->
-  <link href="{{ asset('vendor/sb-admin-2/css/sb-admin-2.min.css') }}" rel="stylesheet">
+    <!-- Custom styles for this template-->
+    <link href="{{ asset('vendor/sb-admin-2/css/sb-admin-2.min.css') }}" rel="stylesheet">
+    <!-- DataTables CSS -->
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">

--- a/resources/views/partials/script.blade.php
+++ b/resources/views/partials/script.blade.php
@@ -7,3 +7,11 @@
 
     <!-- Custom scripts for all pages-->
     <script src="{{ asset('vendor/sb-admin-2/js/sb-admin-2.min.js') }}"></script>
+    <!-- DataTables JS -->
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const tables = document.querySelectorAll('table.table');
+            tables.forEach(t => $(t).DataTable());
+        });
+    </script>


### PR DESCRIPTION
## Summary
- load DataTables CSS and JS globally
- auto-apply DataTables on tables with class `table`

## Testing
- `composer test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_684f4c7c39dc83248d61e6d5a0f2f730