### PR TITLE
Restrict NISN search for logged in students

### DIFF
--- a/resources/views/cek-pembayaran/index.blade.php
+++ b/resources/views/cek-pembayaran/index.blade.php
@@ -12,7 +12,7 @@
         @csrf
         <div class="form-group mb-3">
             <label for="nisn">Masukkan NISN:</label>
-            <input type="text" name="nisn" class="form-control" placeholder="Contoh: 1234567890" required>
+            <input type="text" name="nisn" class="form-control" placeholder="Contoh: 1234567890" required value="{{ $nisn }}" @if($nisn) readonly @endif>
         </div>
         <button type="submit" class="btn btn-primary">Cek Tagihan</button>
     </form>

--- a/resources/views/cek-pembayaran/show.blade.php
+++ b/resources/views/cek-pembayaran/show.blade.php
@@ -15,6 +15,7 @@
         <table class="table table-bordered">
             <thead>
                 <tr>
+                    <th><input type="checkbox" id="select-all"></th>
                     <th>#</th>
                     <th>Jenis</th>
                     <th>Nominal</th>
@@ -25,6 +26,7 @@
             <tbody>
                 @foreach ($iuran as $index => $tagihan)
                     <tr>
+                        <td><input type="checkbox" class="iuran-checkbox" name="iuran_ids[]" value="{{ $tagihan->id }}"></td>
                         <td>{{ $index + 1 }}</td>
                         <td>{{ $tagihan->jenisPembayaran->nama }}</td>
                         <td>Rp {{ number_format($tagihan->jenisPembayaran->nominal, 0, ',', '.') }}</td>
@@ -35,30 +37,33 @@
             </tbody>
         </table>
 
-        <a href="#" class="btn btn-success">Bayar Sekarang (Midtrans)</a> {{-- Tombol dummy --}}
+        <button id="pay-button" class="btn btn-success">Bayar Terpilih</button>
         <script src="https://app.sandbox.midtrans.com/snap/snap.js" data-client-key="{{ env('MIDTRANS_CLIENT_KEY') }}"></script>
         <script type="text/javascript">
-    document.getElementById('pay-button').addEventListener('click', function (e) {
-        e.preventDefault();
-        window.snap.pay('{{ $snapToken }}', {
-            onSuccess: function(result){
-                alert("Pembayaran berhasil.");
-                console.log(result);
-            },
-            onPending: function(result){
-                alert("Menunggu pembayaran.");
-                console.log(result);
-            },
-            onError: function(result){
-                alert("Terjadi kesalahan.");
-                console.log(result);
-            },
-            onClose: function(){
-                alert("Pembayaran dibatalkan.");
-            }
-        });
-    });
-</script
+            document.getElementById('select-all').addEventListener('change', function () {
+                document.querySelectorAll('.iuran-checkbox').forEach(cb => cb.checked = this.checked);
+            });
+            document.getElementById('pay-button').addEventListener('click', function (e) {
+                e.preventDefault();
+                window.snap.pay('{{ $snapToken }}', {
+                    onSuccess: function(result){
+                        alert("Pembayaran berhasil.");
+                        console.log(result);
+                    },
+                    onPending: function(result){
+                        alert("Menunggu pembayaran.");
+                        console.log(result);
+                    },
+                    onError: function(result){
+                        alert("Terjadi kesalahan.");
+                        console.log(result);
+                    },
+                    onClose: function(){
+                        alert("Pembayaran dibatalkan.");
+                    }
+                });
+            });
+        </script>
     @endif
 </div>
 @endsection

--- a/tests/Feature/CekPembayaranTest.php
+++ b/tests/Feature/CekPembayaranTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Middleware\RoleMiddleware;
+use Spatie\Permission\Middleware\PermissionMiddleware;
+use App\Models\User;
+use App\Models\TahunAjaran;
+use App\Models\Kelas;
+use App\Models\Siswa;
+
+class CekPembayaranTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $siswaUser;
+    protected Siswa $siswa1;
+    protected Siswa $siswa2;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Disable Spatie middleware
+        $this->withoutMiddleware([
+            RoleMiddleware::class,
+            PermissionMiddleware::class,
+        ]);
+
+        Role::create(['name' => 'siswa']);
+
+        $ta = TahunAjaran::create(['nama' => '2025/2026', 'semester' => 'Ganjil', 'aktif' => true]);
+        $kelas = Kelas::create(['nama' => 'X', 'kapasitas' => 30, 'tahun_ajaran_id' => $ta->id]);
+
+        $this->siswa1 = Siswa::create([
+            'nis' => '001',
+            'nisn' => '111',
+            'nama_depan' => 'Siswa',
+            'nama_belakang' => 'Satu',
+            'email' => 'siswa1@example.com',
+            'kelas_id' => $kelas->id,
+        ]);
+
+        $this->siswa2 = Siswa::create([
+            'nis' => '002',
+            'nisn' => '222',
+            'nama_depan' => 'Siswa',
+            'nama_belakang' => 'Dua',
+            'email' => 'siswa2@example.com',
+            'kelas_id' => $kelas->id,
+        ]);
+
+        $this->siswaUser = User::factory()->create(['email' => $this->siswa1->email]);
+        $this->siswaUser->assignRole('siswa');
+    }
+
+    public function test_student_cannot_check_other_student_data(): void
+    {
+        $response = $this->actingAs($this->siswaUser)
+            ->post('/cek-pembayaran', ['nisn' => $this->siswa2->nisn]);
+
+        $response->assertSessionHasErrors();
+    }
+}


### PR DESCRIPTION
## Summary
- stop students from checking other students' payment data
- prefill and lock NISN field for logged in students
- add checkboxes to select bills before paying
- add test covering this behavior

## Testing
- `composer test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_684f50ee43ac8324baa3a05c18699bfb