### PR TITLE
Add forced password change for new student accounts

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -22,6 +22,10 @@ class AuthenticatedSessionController extends Controller
         $request->authenticate();
         $request->session()->regenerate();
 
+        if ($request->user()->must_change_password) {
+            return redirect()->route('profile.edit');
+        }
+
         // Redirect sesuai role via RouteServiceProvider::home()
         return redirect()->intended(RouteServiceProvider::home());
     }

--- a/app/Http/Controllers/Auth/PasswordController.php
+++ b/app/Http/Controllers/Auth/PasswordController.php
@@ -22,6 +22,7 @@ class PasswordController extends Controller
 
         $request->user()->update([
             'password' => Hash::make($validated['password']),
+            'must_change_password' => false,
         ]);
 
         return back()->with('status', 'password-updated');

--- a/app/Http/Controllers/SiswaController.php
+++ b/app/Http/Controllers/SiswaController.php
@@ -4,11 +4,14 @@ namespace App\Http\Controllers;
 
 use App\Models\Siswa;
 use App\Models\Kelas;
+use App\Models\User;
 use Illuminate\Http\Request;
 use App\Imports\SiswaImport;
 use Maatwebsite\Excel\Facades\Excel;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Hash;
+use Carbon\Carbon;
 
 class SiswaController extends Controller
 {
@@ -64,6 +67,16 @@ class SiswaController extends Controller
             $v['foto'] = $path;
         }
 
+        $user = User::create([
+            'name' => $v['nama_depan'].' '.$v['nama_belakang'],
+            'email' => $v['email'],
+            'password' => Hash::make('test123'),
+            'must_change_password' => true,
+        ]);
+        $user->assignRole('siswa');
+
+        $v['user_id'] = $user->id;
+
         Siswa::create($v);
 
         return redirect()->route('siswa.index')
@@ -111,6 +124,13 @@ class SiswaController extends Controller
         }
 
         $siswa->update($v);
+
+        if ($siswa->user) {
+            $siswa->user->update([
+                'name' => $v['nama_depan'].' '.$v['nama_belakang'],
+                'email' => $v['email'],
+            ]);
+        }
 
         return redirect()->route('siswa.index')
                          ->with('success','Data siswa berhasil diperbarui.');

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -54,5 +54,6 @@ class Kernel extends HttpKernel
         // Spatie Permission
         'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
         'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
+        'must-change-password' => \App\Http\Middleware\MustChangePassword::class,
     ];
 }

--- a/app/Http/Middleware/MustChangePassword.php
+++ b/app/Http/Middleware/MustChangePassword.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class MustChangePassword
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (auth()->check() && auth()->user()->must_change_password) {
+            if (! $request->routeIs('password.update') &&
+                ! $request->routeIs('profile.edit') &&
+                ! $request->routeIs('logout')) {
+                return redirect()->route('profile.edit');
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Imports/SiswaImport.php
+++ b/app/Imports/SiswaImport.php
@@ -3,6 +3,9 @@
 namespace App\Imports;
 
 use App\Models\Siswa;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Carbon\Carbon;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
 
@@ -10,6 +13,14 @@ class SiswaImport implements ToModel, WithHeadingRow
 {
     public function model(array $row)
     {
+        $user = User::create([
+            'name' => $row['nama_depan'].' '.$row['nama_belakang'],
+            'email' => $row['email'],
+            'password' => Hash::make('test123'),
+            'must_change_password' => true,
+        ]);
+        $user->assignRole('siswa');
+
         return new Siswa([
             'nis'                => $row['nis'],
             'nisn'               => $row['nisn'] ?? null,
@@ -27,6 +38,7 @@ class SiswaImport implements ToModel, WithHeadingRow
             'status_awal_siswa'  => $row['status_awal_siswa'] ?? null,
             'status_akhir_siswa' => $row['status_akhir_siswa'] ?? null,
             'kelas_id'           => $row['kelas_id'],
+            'user_id'            => $user->id,
         ]);
     }
 }

--- a/app/Models/Siswa.php
+++ b/app/Models/Siswa.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Kelas;
 use App\Models\Iuran;
+use App\Models\User;
 
 class Siswa extends Model
 {
@@ -29,6 +30,7 @@ class Siswa extends Model
         'status_awal_siswa',
         'status_akhir_siswa',
         'kelas_id',
+        'user_id',
     ];
 
     /**
@@ -45,5 +47,13 @@ class Siswa extends Model
     public function iuran()
     {
         return $this->hasMany(Iuran::class, 'siswa_id');
+    }
+
+    /**
+     * Relasi ke User (belongsTo)
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
+use App\Models\Siswa;
 
 
 class User extends Authenticatable
@@ -27,6 +28,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'must_change_password',
     ];
 
     /**
@@ -49,6 +51,12 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'must_change_password' => 'boolean',
         ];
+    }
+
+    public function siswa()
+    {
+        return $this->hasOne(Siswa::class);
     }
 }

--- a/database/migrations/2025_06_15_231117_add_user_id_to_siswa_table.php
+++ b/database/migrations/2025_06_15_231117_add_user_id_to_siswa_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('siswa', function (Blueprint $table) {
+            $table->foreignId('user_id')
+                  ->nullable()
+                  ->after('id')
+                  ->constrained()
+                  ->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('siswa', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/database/migrations/2025_06_15_234920_add_must_change_password_to_users_table.php
+++ b/database/migrations/2025_06_15_234920_add_must_change_password_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('must_change_password')->default(false)->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('must_change_password');
+        });
+    }
+};

--- a/database/seeders/SiswaSeeder.php
+++ b/database/seeders/SiswaSeeder.php
@@ -5,6 +5,8 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use App\Models\Siswa;
 use App\Models\Kelas;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
 
 class SiswaSeeder extends Seeder
 {
@@ -15,13 +17,22 @@ class SiswaSeeder extends Seeder
         $kelas = Kelas::all();
         // Buat 3 siswa dummy
         foreach (range(1, end: 3) as $i) {
+            $birth = now()->subYears(15);
+            $user = User::create([
+                'name' => 'Siswa' . $i . ' Test',
+                'email' => "siswa{$i}@example.com",
+                'password' => Hash::make('test123'),
+                'must_change_password' => true,
+            ]);
+            $user->assignRole('siswa');
+
             Siswa::create([
                 'nis' => 'NIS' . str_pad($i, 3, '0', STR_PAD_LEFT),
                 'nisn' => 'NISN' . str_pad($i, 3, '0', STR_PAD_LEFT),
                 'nama_depan' => 'Siswa' . $i,
                 'nama_belakang' => 'Test',
                 'email' => "siswa{$i}@example.com",
-                'tanggal_lahir' => now()->subYears(15)->format('Y-m-d'),
+                'tanggal_lahir' => $birth->format('Y-m-d'),
                 'jenis_kelamin' => $i % 2 ? 'Laki-laki' : 'Perempuan',
                 'alamat' => 'Jl. Contoh No.' . $i,
                 'wali_murid' => 'Orangtua' . $i,
@@ -31,6 +42,7 @@ class SiswaSeeder extends Seeder
                 'status_awal_siswa' => 'baru',
                 'status_akhir_siswa' => 'aktif',
                 'kelas_id' => $kelas->random()->id,
+                'user_id' => $user->id,
             ]);
         }
     }

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -35,7 +35,7 @@ Route::middleware('guest')->group(function () {
         ->name('password.store');
 });
 
-Route::middleware('auth')->group(function () {
+Route::middleware(['auth', 'must-change-password'])->group(function () {
     Route::get('verify-email', EmailVerificationPromptController::class)
         ->name('verification.notice');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,28 +29,28 @@ Route::post('midtrans/callback', [PembayaranController::class, 'callback'])
     ->name('midtrans.callback');
 
 
-Route::middleware('auth')->group(function () {
+Route::middleware(['auth', 'must-change-password'])->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
-Route::group(['middleware' => ['auth', 'role:admin']], function () {
+Route::group(['middleware' => ['auth', 'must-change-password', 'role:admin']], function () {
     Route::resource('tahun-ajaran', TahunAjaranController::class);
 });
 
-Route::group(['middleware' => ['auth', 'role:admin']], function () {
+Route::group(['middleware' => ['auth', 'must-change-password', 'role:admin']], function () {
     Route::resource('kelas', KelasController::class);
 });
 
-Route::group(['middleware' => ['auth', 'role:admin']], function () {
+Route::group(['middleware' => ['auth', 'must-change-password', 'role:admin']], function () {
     Route::resource('siswa', SiswaController::class);
     Route::post('siswa/import', [SiswaController::class, 'import'])
         ->name('siswa.import');
 });
 
 
-Route::group(['middleware' => ['auth', 'role:admin']], function () {
+Route::group(['middleware' => ['auth', 'must-change-password', 'role:admin']], function () {
     // Jenis Pembayaran
     Route::get('jenis-pembayaran', [Modul6Controller::class, 'indexJenis'])->name('jenis.index');
     Route::get('jenis-pembayaran/create', [Modul6Controller::class, 'createJenis'])->name('jenis.create');
@@ -69,7 +69,7 @@ Route::group(['middleware' => ['auth', 'role:admin']], function () {
 });
 
 
-Route::middleware(['auth', 'role:admin|operator'])->group(function () {
+Route::middleware(['auth', 'must-change-password', 'role:admin|operator'])->group(function () {
     Route::get('jurnal-umum', [JurnalUmumController::class, 'index'])
         ->name('jurnal-umum.index');
     Route::get('jurnal-umum/create', [JurnalUmumController::class, 'create'])
@@ -85,7 +85,7 @@ Route::middleware(['auth', 'role:admin|operator'])->group(function () {
 
 
 
-Route::middleware(['auth', 'role:admin|operator'])->group(function () {
+Route::middleware(['auth', 'must-change-password', 'role:admin|operator'])->group(function () {
     // 1) Tampilkan daftar iuran pending
     Route::get('/pembayaran', [PembayaranController::class, 'form'])->name('pembayaran.index');
 
@@ -96,13 +96,13 @@ Route::middleware(['auth', 'role:admin|operator'])->group(function () {
 
 
 // Admin-only dashboard
-Route::middleware(['auth', 'role:admin'])->group(function () {
+Route::middleware(['auth', 'must-change-password', 'role:admin'])->group(function () {
     Route::get('/dashboard', [DashboardController::class, 'admin'])
         ->name('dashboard.admin');
 });
 
 // Siswa-only dashboard
-Route::middleware(['auth', 'role:siswa'])->group(function () {
+Route::middleware(['auth', 'must-change-password', 'role:siswa'])->group(function () {
     Route::get('/dashboard-siswa', [DashboardController::class, 'student'])
         ->name('dashboard.student');
 });
@@ -112,13 +112,13 @@ Route::get('/cek-pembayaran', [CekPembayaranController::class, 'index'])->name('
 Route::post('/cek-pembayaran', [CekPembayaranController::class, 'show'])->name('cek-pembayaran.show');
 
 
-Route::middleware(['auth'])->group(function () {
+Route::middleware(['auth', 'must-change-password'])->group(function () {
     Route::get('/riwayat-transaksi', [RiwayatTransaksiController::class, 'index'])->name('riwayat.index');
     Route::get('/riwayat-transaksi/{id}', [RiwayatTransaksiController::class, 'show'])->name('riwayat.show');
 });
 
 
-Route::middleware(['auth', 'role:admin|operator'])->group(function () {
+Route::middleware(['auth', 'must-change-password', 'role:admin|operator'])->group(function () {
     Route::get('/keuangan', [KeuanganController::class, 'index'])->name('keuangan.index');
     Route::get('/keuangan/tambah', [KeuanganController::class, 'create'])->name('keuangan.create');
     Route::post('/keuangan', [KeuanganController::class, 'store'])->name('keuangan.store');
@@ -128,7 +128,7 @@ Route::get('/keuangan/export-excel', [KeuanganController::class, 'exportExcel'])
 Route::get('/keuangan/cetak-pdf', [KeuanganController::class, 'exportPdf'])->name('keuangan.export-pdf');
 
 
-Route::middleware(['auth', 'role:admin|operator'])->group(function () {
+Route::middleware(['auth', 'must-change-password', 'role:admin|operator'])->group(function () {
     Route::get('/laporan', [LaporanController::class, 'index'])
         ->name('laporan.index');
     Route::post('/laporan', [LaporanController::class, 'generate'])
@@ -140,7 +140,7 @@ Route::middleware(['auth', 'role:admin|operator'])->group(function () {
 });
 
 
-Route::middleware(['auth', 'role:admin'])->group(function () {
+Route::middleware(['auth', 'must-change-password', 'role:admin'])->group(function () {
     // Tampilkan halaman settings
     Route::get('settings', [SettingsController::class, 'index'])->name('settings.index');
 
@@ -160,7 +160,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::post('settings/restore-upload', [SettingsController::class, 'restoreUpload'])->name('settings.restore.upload');
 });
 
-Route::middleware(['auth', 'role:admin'])->group(function () {
+Route::middleware(['auth', 'must-change-password', 'role:admin'])->group(function () {
     Route::resource('users', UserController::class);
 });
 


### PR DESCRIPTION
## Summary
- add `must_change_password` column on users table
- default user password becomes `test123`
- require users to change password after first login
- seeders and imports create users with `must_change_password` flag
- enforce password change via new middleware and route updates

## Testing
- `composer test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_684f52b01544832482dad1e82bd3c0ca