### PR TITLE
Implement basic audit logging

### DIFF
--- a/app/Http/Controllers/AuditLogController.php
+++ b/app/Http/Controllers/AuditLogController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\AuditLog;
+
+class AuditLogController extends Controller
+{
+    public function index()
+    {
+        $logs = AuditLog::with('user')->latest()->paginate(20);
+        return view('audit.index', compact('logs'));
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -29,6 +29,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\AuditLogMiddleware::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/AuditLogMiddleware.php
+++ b/app/Http/Middleware/AuditLogMiddleware.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use App\Models\AuditLog;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuditLogMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        // Skip if running in console or during tests
+        if (app()->runningInConsole()) {
+            return $response;
+        }
+
+        \App\Models\AuditLog::create([
+            'user_id' => optional($request->user())->id,
+            'method' => $request->method(),
+            'url' => $request->fullUrl(),
+            'ip_address' => $request->ip(),
+            'user_agent' => $request->userAgent(),
+        ]);
+
+        return $response;
+    }
+}

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Models\User;
+
+class AuditLog extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'method',
+        'url',
+        'ip_address',
+        'user_agent',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_06_16_032543_create_audit_logs_table.php
+++ b/database/migrations/2025_06_16_032543_create_audit_logs_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')
+                ->nullable()
+                ->constrained()
+                ->nullOnDelete();
+            $table->string('method', 10);
+            $table->text('url');
+            $table->string('ip_address')->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/resources/views/audit/index.blade.php
+++ b/resources/views/audit/index.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.app')
+
+@section('content')
+<h4>Audit Logs</h4>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Waktu</th>
+            <th>User</th>
+            <th>Method</th>
+            <th>URL</th>
+            <th>IP</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach($logs as $log)
+        <tr>
+            <td>{{ $log->created_at }}</td>
+            <td>{{ $log->user->name ?? 'Guest' }}</td>
+            <td>{{ $log->method }}</td>
+            <td>{{ $log->url }}</td>
+            <td>{{ $log->ip_address }}</td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+{{ $logs->links() }}
+@endsection

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -122,6 +122,7 @@
                 <h6 class="collapse-header">Settings</h6>
                 <a class="collapse-item" href="{{ route('users.index') }}">User Management</a>
                 <a class="collapse-item" href="{{ route('settings.index') }}">Application Settings</a>
+                <a class="collapse-item" href="{{ route('audit.index') }}">Audit Logs</a>
             </div>
         </div>
     </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -167,6 +167,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
 
 Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('users', UserController::class);
+    Route::get('audit-logs', [AuditLogController::class, 'index'])->name('audit.index');
 });
 
 

--- a/tests/Feature/AuditLogTest.php
+++ b/tests/Feature/AuditLogTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use App\Models\AuditLog;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Middleware\RoleMiddleware;
+use Spatie\Permission\Middleware\PermissionMiddleware;
+
+class AuditLogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware([
+            RoleMiddleware::class,
+            PermissionMiddleware::class,
+        ]);
+
+        Role::create(['name' => 'admin']);
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('admin');
+    }
+
+    public function test_request_is_logged(): void
+    {
+        $this->actingAs($this->admin)->get('/dashboard');
+
+        $this->assertDatabaseHas('audit_logs', [
+            'user_id' => $this->admin->id,
+            'method' => 'GET',
+            'url' => url('/dashboard'),
+        ]);
+    }
+
+    public function test_admin_can_view_logs(): void
+    {
+        AuditLog::create([
+            'user_id' => $this->admin->id,
+            'method' => 'GET',
+            'url' => url('/test'),
+            'ip_address' => '127.0.0.1',
+            'user_agent' => 'testing',
+        ]);
+
+        $response = $this->actingAs($this->admin)->get('/audit-logs');
+        $response->assertStatus(200)->assertSee('Audit Logs');
+    }
+}
+


### PR DESCRIPTION
## Summary
- log every web request to `audit_logs`
- add middleware and controller for viewing logs
- link audit logs in admin sidebar
- cover audit log behavior with feature tests

## Testing
- `composer install --no-interaction`
- `php artisan test --testsuite=Feature --stop-on-failure` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_684f8e35777c8324af447407dc4880b4