### PR TITLE
Add QR code API and embed codes in PDFs

### DIFF
--- a/app/Http/Controllers/JurnalUmumController.php
+++ b/app/Http/Controllers/JurnalUmumController.php
@@ -7,6 +7,8 @@ use App\Models\JurnalUmum;
 use App\Exports\JurnalUmumExport;
 use Maatwebsite\Excel\Facades\Excel;
 use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Http\JsonResponse;
+use SimpleSoftwareIO\QrCode\Facades\QrCode;
 
 class JurnalUmumController extends Controller
 {
@@ -52,8 +54,21 @@ class JurnalUmumController extends Controller
     public function exportPdf()
     {
         $entries = JurnalUmum::orderByDesc('tanggal')->get();
-        $pdf = Pdf::loadView('jurnal-umum.pdf', compact('entries'))
+        $qr = base64_encode(
+            QrCode::format('png')->size(150)->generate(route('api.jurnal-umum'))
+        );
+        $pdf = Pdf::loadView('jurnal-umum.pdf', compact('entries', 'qr'))
             ->setPaper('a4', 'landscape');
         return $pdf->download('jurnal-umum.pdf');
+    }
+
+    /**
+     * Public API returning JSON jurnal umum entries
+     */
+    public function apiData(): JsonResponse
+    {
+        return response()->json(
+            JurnalUmum::orderByDesc('tanggal')->get()
+        );
     }
 }

--- a/app/Http/Controllers/KeuanganController.php
+++ b/app/Http/Controllers/KeuanganController.php
@@ -9,6 +9,8 @@ use App\Models\Pengeluaran;
 use App\Models\Pembayaran;
 use App\Exports\KeuanganExport;
 use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Http\JsonResponse;
+use SimpleSoftwareIO\QrCode\Facades\QrCode;
 
 class KeuanganController extends Controller
 {
@@ -56,8 +58,22 @@ class KeuanganController extends Controller
     {
         $penerimaan = Penerimaan::with('pembayaran')->orderBy('tanggal', 'desc')->get();
         $pengeluaran = Pengeluaran::orderBy('tanggal', 'desc')->get();
-        $pdf = Pdf::loadView('keuangan.pdf', compact('penerimaan', 'pengeluaran'));
+        $qr = base64_encode(
+            QrCode::format('png')->size(150)->generate(route('api.keuangan'))
+        );
+        $pdf = Pdf::loadView('keuangan.pdf', compact('penerimaan', 'pengeluaran', 'qr'));
         return $pdf->download('laporan-keuangan.pdf');
+    }
+
+    /**
+     * Public API returning JSON keuangan data
+     */
+    public function apiData(): JsonResponse
+    {
+        return response()->json([
+            'penerimaan' => Penerimaan::with('pembayaran')->orderBy('tanggal', 'desc')->get(),
+            'pengeluaran' => Pengeluaran::orderBy('tanggal', 'desc')->get(),
+        ]);
     }
 
 

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "maatwebsite/excel": "3.1.64",
         "midtrans/midtrans-php": "^2.6",
         "phpoffice/phpspreadsheet": "1.29.10",
+        "simplesoftwareio/simple-qrcode": "^4.2",
         "spatie/laravel-backup": "^9.3",
         "spatie/laravel-permission": "^6.19"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,62 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "abc51a5b4fda8cdd4d414fcb18699a84",
+    "content-hash": "9fcc06e203aa11c73154679e8235aa8c",
     "packages": [
+        {
+            "name": "bacon/bacon-qr-code",
+            "version": "2.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bacon/BaconQrCode.git",
+                "reference": "8674e51bb65af933a5ffaf1c308a660387c35c22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/8674e51bb65af933a5ffaf1c308a660387c35c22",
+                "reference": "8674e51bb65af933a5ffaf1c308a660387c35c22",
+                "shasum": ""
+            },
+            "require": {
+                "dasprid/enum": "^1.0.3",
+                "ext-iconv": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phly/keep-a-changelog": "^2.1",
+                "phpunit/phpunit": "^7 | ^8 | ^9",
+                "spatie/phpunit-snapshot-assertions": "^4.2.9",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "suggest": {
+                "ext-imagick": "to generate QR code images"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BaconQrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "BaconQrCode is a QR code generator for PHP.",
+            "homepage": "https://github.com/Bacon/BaconQrCode",
+            "support": {
+                "issues": "https://github.com/Bacon/BaconQrCode/issues",
+                "source": "https://github.com/Bacon/BaconQrCode/tree/2.0.8"
+            },
+            "time": "2022-12-07T17:46:57+00:00"
+        },
         {
             "name": "barryvdh/laravel-dompdf",
             "version": "v3.1.1",
@@ -371,6 +425,56 @@
                 }
             ],
             "time": "2024-09-19T14:15:21+00:00"
+        },
+        {
+            "name": "dasprid/enum",
+            "version": "1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DASPRiD/Enum.git",
+                "reference": "8dfd07c6d2cf31c8da90c53b83c026c7696dda90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/8dfd07c6d2cf31c8da90c53b83c026c7696dda90",
+                "reference": "8dfd07c6d2cf31c8da90c53b83c026c7696dda90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1 <9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DASPRiD\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP 7.1 enum implementation",
+            "keywords": [
+                "enum",
+                "map"
+            ],
+            "support": {
+                "issues": "https://github.com/DASPRiD/Enum/issues",
+                "source": "https://github.com/DASPRiD/Enum/tree/1.0.6"
+            },
+            "time": "2024-08-09T14:30:48+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -4290,6 +4394,74 @@
                 "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.8.0"
             },
             "time": "2025-03-23T17:59:05+00:00"
+        },
+        {
+            "name": "simplesoftwareio/simple-qrcode",
+            "version": "4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SimpleSoftwareIO/simple-qrcode.git",
+                "reference": "916db7948ca6772d54bb617259c768c9cdc8d537"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SimpleSoftwareIO/simple-qrcode/zipball/916db7948ca6772d54bb617259c768c9cdc8d537",
+                "reference": "916db7948ca6772d54bb617259c768c9cdc8d537",
+                "shasum": ""
+            },
+            "require": {
+                "bacon/bacon-qr-code": "^2.0",
+                "ext-gd": "*",
+                "php": ">=7.2|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1",
+                "phpunit/phpunit": "~9"
+            },
+            "suggest": {
+                "ext-imagick": "Allows the generation of PNG QrCodes.",
+                "illuminate/support": "Allows for use within Laravel."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "QrCode": "SimpleSoftwareIO\\QrCode\\Facades\\QrCode"
+                    },
+                    "providers": [
+                        "SimpleSoftwareIO\\QrCode\\QrCodeServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SimpleSoftwareIO\\QrCode\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Simple Software LLC",
+                    "email": "support@simplesoftware.io"
+                }
+            ],
+            "description": "Simple QrCode is a QR code generator made for Laravel.",
+            "homepage": "https://www.simplesoftware.io/#/docs/simple-qrcode",
+            "keywords": [
+                "Simple",
+                "generator",
+                "laravel",
+                "qrcode",
+                "wrapper"
+            ],
+            "support": {
+                "issues": "https://github.com/SimpleSoftwareIO/simple-qrcode/issues",
+                "source": "https://github.com/SimpleSoftwareIO/simple-qrcode/tree/4.2.0"
+            },
+            "time": "2021-02-08T20:43:55+00:00"
         },
         {
             "name": "spatie/db-dumper",
@@ -9603,12 +9775,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/resources/views/jurnal-umum/pdf.blade.php
+++ b/resources/views/jurnal-umum/pdf.blade.php
@@ -50,6 +50,10 @@
             @endforeach
         </tbody>
     </table>
+    <div style="text-align:center;margin-top:20px">
+        <img src="data:image/png;base64,{{ $qr }}" alt="QR Code">
+        <p>Scan untuk data JSON</p>
+    </div>
 </body>
 
 </html>

--- a/resources/views/keuangan/pdf.blade.php
+++ b/resources/views/keuangan/pdf.blade.php
@@ -42,5 +42,9 @@
             @endforeach
         </tbody>
     </table>
+    <div style="text-align:center;margin-top:20px">
+        <img src="data:image/png;base64,{{ $qr }}" alt="QR Code">
+        <p>Scan untuk data JSON</p>
+    </div>
 </body>
 </html>

--- a/resources/views/laporan/pdf.blade.php
+++ b/resources/views/laporan/pdf.blade.php
@@ -42,6 +42,10 @@
             @endforeach
         </tbody>
     </table>
+    <div style="text-align:center;margin-top:20px">
+        <img src="data:image/png;base64,{{ $qr }}" alt="QR Code">
+        <p>Scan untuk data JSON</p>
+    </div>
 </body>
 
 </html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,9 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PembayaranController;
+use App\Http\Controllers\KeuanganController;
+use App\Http\Controllers\JurnalUmumController;
+use App\Http\Controllers\LaporanController;
 
 /*
 |--------------------------------------------------------------------------
@@ -13,3 +16,7 @@ use App\Http\Controllers\PembayaranController;
 
 Route::post('midtrans/callback', [PembayaranController::class, 'callback'])
     ->name('midtrans.callback');
+
+Route::get('keuangan', [KeuanganController::class, 'apiData'])->name('api.keuangan');
+Route::get('jurnal-umum', [JurnalUmumController::class, 'apiData'])->name('api.jurnal-umum');
+Route::get('laporan', [LaporanController::class, 'apiData'])->name('api.laporan');


### PR DESCRIPTION
## Summary
- install `simplesoftwareio/simple-qrcode`
- expose new public API routes for keuangan, jurnal umum and laporan
- generate QR codes linking to these APIs and include them in exported PDFs

## Testing
- `composer test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_684f943cb9a083248afe5a38c57f7780