### PR TITLE
Fix missing API routes

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )


### PR DESCRIPTION
## Summary
- load API routes so that api.laporan is defined

## Testing
- `php artisan route:list --name=api.laporan`
- `php artisan test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6859d6fd6a888324b2f66e23e56a664a