### PR TITLE
Add academic calendar on admin dashboard

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Auth;
 use App\Models\Siswa;
 use App\Models\Iuran;
 use App\Models\Pembayaran;
+use App\Models\TahunAjaran;
 
 class DashboardController extends Controller
 {
@@ -43,13 +44,30 @@ class DashboardController extends Controller
             ])
             ->get();
 
+        $activeYear = TahunAjaran::with('bulan')->where('aktif', true)->first();
+        $calendarEvents = [];
+        if ($activeYear) {
+            [$yearStart, $yearEnd] = array_map('intval', explode('/', $activeYear->nama));
+            foreach ($activeYear->bulan as $b) {
+                $year = $b->urutan >= 7 ? $yearStart : $yearEnd;
+                $date = sprintf('%04d-%02d-01', $year, $b->urutan);
+                $calendarEvents[] = [
+                    'title' => $b->nama,
+                    'start' => $date,
+                ];
+            }
+        }
+
+        $calendarEvents = json_encode($calendarEvents);
+
         return view('dashboard.admin', compact(
             'activeStudents',
             'paymentsThisMonth',
             'pendingStudents',
             'totalReceived',
             'totalPending',
-            'studentPayments'
+            'studentPayments',
+            'calendarEvents'
         ));
     }
 

--- a/resources/views/dashboard/admin.blade.php
+++ b/resources/views/dashboard/admin.blade.php
@@ -31,24 +31,32 @@
     </div>
     </div>
 
-    <div class="col-xl-4 col-lg-5">
-    <div class="card shadow mb-4">
-      <!-- Card Header - Dropdown -->
-      <div class="card-header py-3">
-      <h6 class="m-0 font-weight-bold text-primary">Rekapitulasi Pembayaran</h6>
+    <div class="row mt-4">
+      <div class="col-xl-6 col-lg-6 mb-4">
+        <div class="card shadow mb-4">
+          <div class="card-header py-3">
+            <h6 class="m-0 font-weight-bold text-primary">Rekapitulasi Pembayaran</h6>
+          </div>
+          <div class="card-body">
+            <div class="chart-pie pt-4">
+              <canvas id="paymentChart"></canvas>
+            </div>
+            <hr>
+            Total terbayar: {{ $totalReceived }} <br>
+            Total pending: {{  $totalPending }}
+          </div>
+        </div>
       </div>
-      <!-- Card Body -->
-      <div class="card-body">
-      <div class="chart-pie pt-4">
-        <canvas id="paymentChart"></canvas>
+      <div class="col-xl-6 col-lg-6 mb-4">
+        <div class="card shadow mb-4">
+          <div class="card-header py-3">
+            <h6 class="m-0 font-weight-bold text-primary">Kalender Akademik</h6>
+          </div>
+          <div class="card-body">
+            <div id="academicCalendar"></div>
+          </div>
+        </div>
       </div>
-      <hr>
-      Total terbayar: {{ $totalReceived }} <br>
-      Total pending: {{  $totalPending }}
-      {{-- Styling for the donut chart can be found in the
-      <code>/js/demo/chart-pie-demo.js</code> file. --}}
-      </div>
-    </div>
     </div>
 
     <div class="card shadow-sm mt-4">
@@ -81,8 +89,13 @@
   </div>
 @endsection
 
-@push('scripts')
+  @push('styles')
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css">
+  @endpush
+
+  @push('scripts')
   <script src="{{ asset('vendor/sb-admin-2/vendor/chart.js/Chart.min.js') }}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
     new Chart(document.getElementById('paymentChart'), {
@@ -101,6 +114,13 @@
       plugins: { legend: { position: 'bottom' } }
       }
     });
+
+    const cal = new FullCalendar.Calendar(document.getElementById('academicCalendar'), {
+      initialView: 'dayGridMonth',
+      height: 350,
+      events: {!! $calendarEvents !!}
+    });
+    cal.render();
     });
   </script>
-@endpush
+  @endpush

--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -16,3 +16,5 @@
     <link href="{{ asset('vendor/sb-admin-2/css/sb-admin-2.min.css') }}" rel="stylesheet">
     <!-- DataTables CSS -->
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
+
+    @stack('styles')


### PR DESCRIPTION
## Summary
- show academic calendar next to payment chart
- wire up FullCalendar assets and initialization script
- expose academic calendar events from DashboardController
- allow page-specific styles via stack

## Testing
- `php artisan test` *(fails: could not find driver)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859dc65f9548324a1da9ab243e31a44