### PR TITLE
Add calendar event management

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -8,6 +8,7 @@ use App\Models\Siswa;
 use App\Models\Iuran;
 use App\Models\Pembayaran;
 use App\Models\TahunAjaran;
+use App\Models\Event;
 
 class DashboardController extends Controller
 {
@@ -56,6 +57,14 @@ class DashboardController extends Controller
                     'start' => $date,
                 ];
             }
+        }
+
+        foreach (Event::orderBy('start_date')->get() as $ev) {
+            $calendarEvents[] = [
+                'title' => $ev->title,
+                'start' => $ev->start_date->toDateString(),
+                'end'   => $ev->end_date?->toDateString(),
+            ];
         }
 
         $calendarEvents = json_encode($calendarEvents);

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Event;
+use Illuminate\Http\Request;
+
+class EventController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'role:admin']);
+    }
+
+    public function index()
+    {
+        $events = Event::orderBy('start_date')->get();
+        return view('event.index', compact('events'));
+    }
+
+    public function create()
+    {
+        $event = new Event();
+        return view('event.form', [
+            'event' => $event,
+            'action' => route('events.store'),
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'title' => 'required|string|max:100',
+            'start_date' => 'required|date',
+            'end_date' => 'nullable|date|after_or_equal:start_date',
+        ]);
+        Event::create($data);
+        return redirect()->route('events.index')
+            ->with('success', 'Event berhasil ditambahkan.');
+    }
+
+    public function edit(Event $event)
+    {
+        return view('event.form', [
+            'event' => $event,
+            'action' => route('events.update', $event),
+        ]);
+    }
+
+    public function update(Request $request, Event $event)
+    {
+        $data = $request->validate([
+            'title' => 'required|string|max:100',
+            'start_date' => 'required|date',
+            'end_date' => 'nullable|date|after_or_equal:start_date',
+        ]);
+        $event->update($data);
+        return redirect()->route('events.index')
+            ->with('success', 'Event berhasil diperbarui.');
+    }
+
+    public function destroy(Event $event)
+    {
+        $event->delete();
+        return redirect()->route('events.index')
+            ->with('success', 'Event berhasil dihapus.');
+    }
+}

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Event extends Model
+{
+    protected $table = 'events';
+
+    protected $fillable = ['title', 'start_date', 'end_date'];
+
+    protected $casts = [
+        'start_date' => 'date',
+        'end_date' => 'date',
+    ];
+}

--- a/database/migrations/2025_06_24_000000_create_events_table.php
+++ b/database/migrations/2025_06_24_000000_create_events_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('events', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->date('start_date');
+            $table->date('end_date')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('events');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,7 @@
         <env name="CACHE_STORE" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
+        <env name="APP_KEY" value="base64:hmSUQyPvCSdJdgS7Jxza+otlX+7A7iuYGKpDxkqy4Is="/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/resources/views/event/form.blade.php
+++ b/resources/views/event/form.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.app')
+@section('content')
+<div class="container">
+    <h3>{{ $event->exists ? 'Edit' : 'Tambah' }} Event</h3>
+    <form action="{{ $action }}" method="POST">
+        @csrf
+        @if($event->exists)
+            @method('PUT')
+        @endif
+        <div class="form-group">
+            <label>Judul</label>
+            <input name="title" class="form-control" value="{{ old('title', $event->title) }}" required>
+            @error('title')<small class="text-danger">{{ $message }}</small>@enderror
+        </div>
+        <div class="form-group">
+            <label>Tanggal Mulai</label>
+            <input type="date" name="start_date" class="form-control" value="{{ old('start_date', optional($event->start_date)->format('Y-m-d')) }}" required>
+            @error('start_date')<small class="text-danger">{{ $message }}</small>@enderror
+        </div>
+        <div class="form-group">
+            <label>Tanggal Selesai</label>
+            <input type="date" name="end_date" class="form-control" value="{{ old('end_date', optional($event->end_date)->format('Y-m-d')) }}">
+            @error('end_date')<small class="text-danger">{{ $message }}</small>@enderror
+        </div>
+        <button class="btn btn-success">{{ $event->exists ? 'Perbarui' : 'Simpan' }}</button>
+        <a href="{{ route('events.index') }}" class="btn btn-secondary">Batal</a>
+    </form>
+</div>
+@endsection

--- a/resources/views/event/index.blade.php
+++ b/resources/views/event/index.blade.php
@@ -1,0 +1,38 @@
+@extends('layouts.app')
+@section('content')
+<div class="container">
+    @if(session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+    <a href="{{ route('events.create') }}" class="btn btn-primary mb-3">
+        <i class="fas fa-plus"></i> Tambah Event
+    </a>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Judul</th>
+                <th>Mulai</th>
+                <th>Selesai</th>
+                <th>Aksi</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($events as $e)
+            <tr>
+                <td>{{ $e->title }}</td>
+                <td>{{ $e->start_date->format('Y-m-d') }}</td>
+                <td>{{ $e->end_date ? $e->end_date->format('Y-m-d') : '-' }}</td>
+                <td>
+                    <a href="{{ route('events.edit', $e) }}" class="btn btn-sm btn-warning">Edit</a>
+                    <form action="{{ route('events.destroy', $e) }}" method="POST" class="d-inline" onsubmit="return confirm('Hapus event ini?')">
+                        @csrf
+                        @method('DELETE')
+                        <button class="btn btn-sm btn-danger">Hapus</button>
+                    </form>
+                </td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>
+@endsection

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -56,6 +56,12 @@
             <span>Tahun Akademik</span></a>
     </li>
 
+    <li class="nav-item">
+        <a class="nav-link" href="{{ route('events.index') }}">
+            <i class="fas fa-fw fa-calendar"></i>
+            <span>Event</span></a>
+    </li>
+
 
     <!-- Nav Item - Components Collapse Menu -->
     <li class="nav-item">

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,6 +51,10 @@ Route::group(['middleware' => ['auth', 'role:admin']], function () {
 });
 
 Route::group(['middleware' => ['auth', 'role:admin']], function () {
+    Route::resource('events', EventController::class);
+});
+
+Route::group(['middleware' => ['auth', 'role:admin']], function () {
     Route::resource('siswa', SiswaController::class)->except(['show']);
     Route::post('siswa/import', [SiswaController::class, 'import'])->name('siswa.import');
     Route::get('siswa/template', [SiswaController::class, 'downloadTemplate'])->name('siswa.template');

--- a/tests/Feature/AdminDashboardTest.php
+++ b/tests/Feature/AdminDashboardTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Models\TahunAjaran;
 use App\Models\Kelas;
 use App\Models\Siswa;
+use App\Models\Event;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Middleware\RoleMiddleware;
 use Spatie\Permission\Middleware\PermissionMiddleware;
@@ -60,6 +61,19 @@ class AdminDashboardTest extends TestCase
         $response->assertStatus(200)
                  ->assertSee('id="paymentChart"', false)
                  ->assertSee('Status Pembayaran Siswa');
+    }
+
+    public function test_calendar_contains_events(): void
+    {
+        Event::create([
+            'title' => 'Ujian Akhir',
+            'start_date' => '2025-07-01',
+        ]);
+
+        $response = $this->actingAs($this->admin)->get('/dashboard');
+
+        $response->assertStatus(200)
+                 ->assertSee('Ujian Akhir');
     }
 }
 

--- a/tests/Feature/EventCrudTest.php
+++ b/tests/Feature/EventCrudTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Middleware\RoleMiddleware;
+use Spatie\Permission\Middleware\PermissionMiddleware;
+use Tests\TestCase;
+
+class EventCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware([
+            RoleMiddleware::class,
+            PermissionMiddleware::class,
+        ]);
+        Role::create(['name' => 'admin']);
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('admin');
+    }
+
+    public function test_admin_can_crud_event(): void
+    {
+        $response = $this->actingAs($this->admin)->get('/events');
+        $response->assertStatus(200);
+
+        $response = $this->actingAs($this->admin)->get('/events/create');
+        $response->assertStatus(200);
+
+        $data = [
+            'title' => 'MPLS',
+            'start_date' => '2025-07-10',
+            'end_date' => '2025-07-12',
+        ];
+        $this->actingAs($this->admin)
+            ->post('/events', $data)
+            ->assertRedirect('/events');
+        $this->assertDatabaseHas('events', ['title' => 'MPLS']);
+
+        $event = Event::where('title', 'MPLS')->first();
+
+        $response = $this->actingAs($this->admin)->get("/events/{$event->id}/edit");
+        $response->assertStatus(200);
+
+        $update = array_merge($data, ['title' => 'Updated MPLS']);
+        $this->actingAs($this->admin)
+            ->put("/events/{$event->id}", $update)
+            ->assertRedirect('/events');
+        $this->assertDatabaseHas('events', ['title' => 'Updated MPLS']);
+
+        $this->actingAs($this->admin)
+            ->delete("/events/{$event->id}")
+            ->assertRedirect('/events');
+        $this->assertDatabaseMissing('events', ['id' => $event->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- create events table and model
- add CRUD controller and views for events
- display events on the admin dashboard calendar
- expose event management routes
- update sidebar navigation
- include tests for event CRUD and dashboard calendar
- configure APP_KEY for tests

## Testing
- `composer test` *(fails: 16 failed, 35 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6859dfb2d08083249850780ddacd30f6