### PR TITLE
Add bulk student status management page

### DIFF
--- a/app/Http/Controllers/SiswaController.php
+++ b/app/Http/Controllers/SiswaController.php
@@ -18,16 +18,17 @@ class SiswaController extends Controller
     public function __construct()
     {
         $this->middleware('auth');
-        $this->middleware('permission:view siswa')->only('index');
+        $this->middleware('permission:view siswa')->only(['index', 'ref']);
         $this->middleware('permission:create siswa')->only(['create', 'store', 'import']);
-        $this->middleware('permission:edit siswa')->only(['edit', 'update']);
+        $this->middleware('permission:edit siswa')->only(['edit', 'update', 'naikKelas', 'pindahSekolah', 'lulus', 'applyRef']);
         $this->middleware('permission:delete siswa')->only('destroy');
     }
 
     public function index()
     {
         $data = Siswa::with('kelas')->orderBy('nis')->paginate(15);
-        return view('siswa.index', compact('data'));
+        $kelasList = Kelas::orderBy('nama')->get();
+        return view('siswa.index', compact('data', 'kelasList'));
     }
 
     public function create()
@@ -167,5 +168,81 @@ class SiswaController extends Controller
             'template_import_siswa.csv',
             ['Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']
         );
+    }
+
+    public function ref(Request $req)
+    {
+        $kelasList = Kelas::orderBy('nama')->get();
+        $selectedKelas = $req->query('kelas');
+        $query = Siswa::with('kelas')->orderBy('nis');
+        if ($selectedKelas) {
+            $query->where('kelas_id', $selectedKelas);
+        }
+        $siswaList = $query->paginate(20);
+
+        return view('siswa.ref', compact('kelasList', 'siswaList', 'selectedKelas'));
+    }
+
+    public function applyRef(Request $req)
+    {
+        $v = $req->validate([
+            'siswa_ids' => 'required|array',
+            'siswa_ids.*' => 'exists:siswa,id',
+            'action' => 'required|in:naik,pindah,lulus',
+            'kelas_id' => 'required_if:action,naik|exists:kelas,id',
+        ]);
+
+        $ids = $v['siswa_ids'];
+
+        switch ($v['action']) {
+            case 'naik':
+                Siswa::whereIn('id', $ids)->update(['kelas_id' => $v['kelas_id']]);
+                break;
+            case 'pindah':
+                Siswa::whereIn('id', $ids)->update([
+                    'status_siswa' => 'nonaktif',
+                    'status_akhir_siswa' => 'pindah',
+                ]);
+                break;
+            case 'lulus':
+                Siswa::whereIn('id', $ids)->update([
+                    'status_siswa' => 'lulus',
+                    'status_akhir_siswa' => 'lulus',
+                ]);
+                break;
+        }
+
+        return back()->with('success', 'Status siswa berhasil diperbarui.');
+    }
+
+    public function naikKelas(Request $req, Siswa $siswa)
+    {
+        $v = $req->validate([
+            'kelas_id' => 'required|exists:kelas,id',
+        ]);
+
+        $siswa->update(['kelas_id' => $v['kelas_id']]);
+
+        return back()->with('success', 'Siswa berhasil naik kelas.');
+    }
+
+    public function pindahSekolah(Siswa $siswa)
+    {
+        $siswa->update([
+            'status_siswa' => 'nonaktif',
+            'status_akhir_siswa' => 'pindah',
+        ]);
+
+        return back()->with('success', 'Status siswa diperbarui menjadi pindah.');
+    }
+
+    public function lulus(Siswa $siswa)
+    {
+        $siswa->update([
+            'status_siswa' => 'lulus',
+            'status_akhir_siswa' => 'lulus',
+        ]);
+
+        return back()->with('success', 'Status siswa diperbarui menjadi lulus.');
     }
 }

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -69,6 +69,7 @@
             <div class="bg-white py-2 collapse-inner rounded">
                 <h6 class="collapse-header">Data Siswa</h6>
                 <a class="collapse-item" href="{{ route('siswa.index') }}">Biodata Siswa</a>
+                <a class="collapse-item" href="{{ route('siswa.ref') }}">Kelola Status</a>
             </div>
         </div>
     </li>

--- a/resources/views/siswa/index.blade.php
+++ b/resources/views/siswa/index.blade.php
@@ -59,10 +59,26 @@
       </td>
       <td>
       <a href="{{ route('siswa.edit', $s) }}" class="btn btn-sm btn-warning">Edit</a>
-      <form action="{{ route('siswa.destroy', $s) }}" method="POST" class="d-inline"
-      onsubmit="return confirm('Hapus siswa ini?')">
-      @csrf @method('DELETE')
-      <button class="btn btn-sm btn-danger">Hapus</button>
+      <form action="{{ route('siswa.naik-kelas', $s) }}" method="POST" class="d-inline">
+        @csrf
+        <select name="kelas_id" class="form-control form-control-sm d-inline w-auto">
+          @foreach($kelasList as $k)
+            <option value="{{ $k->id }}" {{ $k->id == $s->kelas_id ? 'selected' : '' }}>{{ $k->nama }}</option>
+          @endforeach
+        </select>
+        <button class="btn btn-sm btn-info">Naik</button>
+      </form>
+      <form action="{{ route('siswa.pindah', $s) }}" method="POST" class="d-inline" onsubmit="return confirm('Pindahkan siswa ini?')">
+        @csrf
+        <button class="btn btn-sm btn-secondary">Pindah</button>
+      </form>
+      <form action="{{ route('siswa.lulus', $s) }}" method="POST" class="d-inline" onsubmit="return confirm('Luluskan siswa ini?')">
+        @csrf
+        <button class="btn btn-sm btn-success">Lulus</button>
+      </form>
+      <form action="{{ route('siswa.destroy', $s) }}" method="POST" class="d-inline" onsubmit="return confirm('Hapus siswa ini?')">
+        @csrf @method('DELETE')
+        <button class="btn btn-sm btn-danger">Hapus</button>
       </form>
       </td>
     </tr>

--- a/resources/views/siswa/ref.blade.php
+++ b/resources/views/siswa/ref.blade.php
@@ -1,0 +1,62 @@
+@extends('layouts.app')
+@section('content')
+<div class="container">
+    <h3>Kelola Status Siswa</h3>
+    @if(session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+    <form method="GET" class="form-inline mb-3">
+        <label class="mr-2">Filter Kelas</label>
+        <select name="kelas" class="form-control mr-2" onchange="this.form.submit()">
+            <option value="">-- Semua Kelas --</option>
+            @foreach($kelasList as $k)
+                <option value="{{ $k->id }}" {{ $selectedKelas == $k->id ? 'selected' : '' }}>{{ $k->nama }}</option>
+            @endforeach
+        </select>
+    </form>
+
+    <form action="{{ route('siswa.ref.apply') }}" method="POST">
+        @csrf
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th><input type="checkbox" id="select-all"></th>
+                    <th>NIS</th>
+                    <th>Nama</th>
+                    <th>Kelas</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($siswaList as $s)
+                <tr>
+                    <td><input type="checkbox" class="siswa-checkbox" name="siswa_ids[]" value="{{ $s->id }}"></td>
+                    <td>{{ $s->nis }}</td>
+                    <td>{{ $s->nama_depan }} {{ $s->nama_belakang }}</td>
+                    <td>{{ $s->kelas->nama }}</td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+
+        <div class="form-group">
+            <select name="kelas_id" class="form-control d-inline w-auto">
+                <option value="">Pilih Kelas Baru...</option>
+                @foreach($kelasList as $k)
+                    <option value="{{ $k->id }}">{{ $k->nama }}</option>
+                @endforeach
+            </select>
+            <button type="submit" name="action" value="naik" class="btn btn-info">Naik Kelas</button>
+            <button type="submit" name="action" value="pindah" class="btn btn-secondary">Pindah Sekolah</button>
+            <button type="submit" name="action" value="lulus" class="btn btn-success">Luluskan</button>
+        </div>
+    </form>
+    {{ $siswaList->withQueryString()->links() }}
+</div>
+<script>
+    const selectAll = document.getElementById('select-all');
+    const checkboxes = document.querySelectorAll('.siswa-checkbox');
+    selectAll.addEventListener('change', function(){
+        checkboxes.forEach(cb => cb.checked = this.checked);
+    });
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,6 +53,11 @@ Route::group(['middleware' => ['auth', 'role:admin']], function () {
     Route::resource('siswa', SiswaController::class)->except(['show']);
     Route::post('siswa/import', [SiswaController::class, 'import'])->name('siswa.import');
     Route::get('siswa/template', [SiswaController::class, 'downloadTemplate'])->name('siswa.template');
+    Route::get('siswa/ref', [SiswaController::class, 'ref'])->name('siswa.ref');
+    Route::post('siswa/ref', [SiswaController::class, 'applyRef'])->name('siswa.ref.apply');
+    Route::post('siswa/{siswa}/naik-kelas', [SiswaController::class, 'naikKelas'])->name('siswa.naik-kelas');
+    Route::post('siswa/{siswa}/pindah', [SiswaController::class, 'pindahSekolah'])->name('siswa.pindah');
+    Route::post('siswa/{siswa}/lulus', [SiswaController::class, 'lulus'])->name('siswa.lulus');
 });
 
 

--- a/tests/Feature/SiswaStatusTest.php
+++ b/tests/Feature/SiswaStatusTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use App\Models\TahunAjaran;
+use App\Models\Kelas;
+use App\Models\Siswa;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Middleware\RoleMiddleware;
+use Spatie\Permission\Middleware\PermissionMiddleware;
+
+class SiswaStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+    protected Kelas $kelas1;
+    protected Kelas $kelas2;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $role = Role::create(['name' => 'admin']);
+        $perm = Permission::create(['name' => 'edit siswa']);
+        $role->givePermissionTo($perm);
+
+        $this->withoutMiddleware([
+            RoleMiddleware::class,
+            PermissionMiddleware::class,
+        ]);
+
+        $this->admin = User::factory()->create();
+        $this->admin->assignRole('admin');
+
+        $ta = TahunAjaran::create([
+            'nama' => '2025/2026',
+            'semester' => 'Ganjil',
+            'aktif' => true,
+        ]);
+
+        $this->kelas1 = Kelas::create([
+            'nama' => 'X IPA',
+            'kapasitas' => 30,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+
+        $this->kelas2 = Kelas::create([
+            'nama' => 'XI IPA',
+            'kapasitas' => 30,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+    }
+
+    public function test_admin_can_promote_transfer_and_graduate_siswa(): void
+    {
+        $siswa = Siswa::create([
+            'nis' => '111',
+            'nama_depan' => 'Test',
+            'nama_belakang' => 'Student',
+            'email' => 'test@example.com',
+            'kelas_id' => $this->kelas1->id,
+        ]);
+
+        // naik kelas
+        $this->actingAs($this->admin)
+            ->post("/siswa/{$siswa->id}/naik-kelas", [
+                'kelas_id' => $this->kelas2->id,
+            ])
+            ->assertRedirect();
+        $this->assertDatabaseHas('siswa', [
+            'id' => $siswa->id,
+            'kelas_id' => $this->kelas2->id,
+        ]);
+
+        // pindah sekolah
+        $this->actingAs($this->admin)
+            ->post("/siswa/{$siswa->id}/pindah")
+            ->assertRedirect();
+        $this->assertDatabaseHas('siswa', [
+            'id' => $siswa->id,
+            'status_siswa' => 'nonaktif',
+            'status_akhir_siswa' => 'pindah',
+        ]);
+
+        // lulus
+        $this->actingAs($this->admin)
+            ->post("/siswa/{$siswa->id}/lulus")
+            ->assertRedirect();
+        $this->assertDatabaseHas('siswa', [
+            'id' => $siswa->id,
+            'status_siswa' => 'lulus',
+            'status_akhir_siswa' => 'lulus',
+        ]);
+    }
+
+    public function test_admin_can_bulk_update_status(): void
+    {
+        $siswa1 = Siswa::create([
+            'nis' => '111',
+            'nama_depan' => 'One',
+            'nama_belakang' => 'Student',
+            'email' => 'one@example.com',
+            'kelas_id' => $this->kelas1->id,
+        ]);
+        $siswa2 = Siswa::create([
+            'nis' => '112',
+            'nama_depan' => 'Two',
+            'nama_belakang' => 'Student',
+            'email' => 'two@example.com',
+            'kelas_id' => $this->kelas1->id,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->post('/siswa/ref', [
+                'siswa_ids' => [$siswa1->id, $siswa2->id],
+                'kelas_id' => $this->kelas2->id,
+                'action' => 'naik',
+            ])
+            ->assertRedirect();
+        $this->assertDatabaseHas('siswa', ['id' => $siswa1->id, 'kelas_id' => $this->kelas2->id]);
+        $this->assertDatabaseHas('siswa', ['id' => $siswa2->id, 'kelas_id' => $this->kelas2->id]);
+
+        $this->actingAs($this->admin)
+            ->post('/siswa/ref', [
+                'siswa_ids' => [$siswa1->id, $siswa2->id],
+                'action' => 'pindah',
+            ])
+            ->assertRedirect();
+        $this->assertDatabaseHas('siswa', ['id' => $siswa1->id, 'status_akhir_siswa' => 'pindah']);
+
+        $this->actingAs($this->admin)
+            ->post('/siswa/ref', [
+                'siswa_ids' => [$siswa1->id, $siswa2->id],
+                'action' => 'lulus',
+            ])
+            ->assertRedirect();
+        $this->assertDatabaseHas('siswa', ['id' => $siswa2->id, 'status_siswa' => 'lulus']);
+    }
+}


### PR DESCRIPTION
## Summary
- manage student promotions, transfers and graduations in one page
- provide sidebar link to open the bulk status page
- handle bulk actions via new controller methods and routes
- test bulk status updates

## Testing
- `composer test` *(fails: some feature tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6859dc08e32083248d15667409114de3