### PR TITLE
Add column filter to all tables

### DIFF
--- a/resources/views/partials/script.blade.php
+++ b/resources/views/partials/script.blade.php
@@ -12,6 +12,24 @@
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const tables = document.querySelectorAll('table.table');
-            tables.forEach(t => $(t).DataTable());
+            tables.forEach(table => {
+                const dt = $(table).DataTable();
+
+                // Add a filter input for each column
+                const header = table.tHead;
+                if (!header) return;
+                const filterRow = header.insertRow(-1);
+                Array.from(header.rows[0].cells).forEach((th, idx) => {
+                    const cell = filterRow.insertCell(idx);
+                    const input = document.createElement('input');
+                    input.type = 'text';
+                    input.classList.add('form-control', 'form-control-sm');
+                    input.placeholder = 'Filter';
+                    input.addEventListener('keyup', () => {
+                        dt.column(idx).search(input.value).draw();
+                    });
+                    cell.appendChild(input);
+                });
+            });
         });
     </script>


### PR DESCRIPTION
## Summary
- enhance DataTables setup by adding a per‑column filter row for every table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b283f783c8324a7a70b76faaf374d